### PR TITLE
ci: remove duplicate 'Get git version' step

### DIFF
--- a/.github/workflows/build-argocdinit.yml
+++ b/.github/workflows/build-argocdinit.yml
@@ -35,12 +35,6 @@ jobs:
           version=$(git describe --tags --always --dirty 2>/dev/null || echo "latest")
           echo "version=$version" >> $GITHUB_OUTPUT
 
-      - name: Get git version
-        id: ver
-        run: |
-          version=$(git describe --tags --always --dirty 2>/dev/null || echo "latest")
-          echo "version=$version" >> $GITHUB_OUTPUT
-
       - name: Build image (Makefile)
         run: |
           # Build via Makefile (creates builder and OCI tar)


### PR DESCRIPTION
Remove duplicated 'Get git version' step from CI workflow. This PR was created automatically by the local helper to merge the workflow fix into main.