### PR TITLE
ci: build test image before running BATS

### DIFF
--- a/.github/workflows/build-argocdinit.yml
+++ b/.github/workflows/build-argocdinit.yml
@@ -37,8 +37,9 @@ jobs:
 
       - name: Build image (Makefile)
         run: |
-          # Build via Makefile (creates builder and OCI tar)
-          make -C argocd/argocdinit all
+          # Build via Makefile and create a test image (single-platform) for downstream tests
+          # `make test` builds and --load a linux/amd64 image tagged with -test-linux-amd64
+          make -C argocd/argocdinit test
 
       - name: Generate SBOM (Makefile)
         run: |


### PR DESCRIPTION
Ensure CI builds and loads the single-platform test image before running BATS by using 'make test' in the workflow. This aligns tags used by the tests with the image built by the Makefile.