### PR TITLE
ci: use platform-suffixed test image for goss container

### DIFF
--- a/.github/workflows/build-argocdinit.yml
+++ b/.github/workflows/build-argocdinit.yml
@@ -60,7 +60,8 @@ jobs:
 
       - name: Start test container for goss
         run: |
-          export IMAGE=awendt/argocdinit:${{ steps.ver.outputs.version }}-test
+          # Use the same platform-suffixed test image created by make test
+          export IMAGE=awendt/argocdinit:${{ steps.ver.outputs.version }}-test-linux-amd64
           docker run -d --name test-container $IMAGE sleep infinity
 
       - name: Run goss checks


### PR DESCRIPTION
Start the goss test container using the same platform-suffixed image tag (-linux-amd64) that Makefile builds to ensure the container exists locally.
