### PR TITLE
ci: goss — use absolute path to goss.yaml

### DIFF
--- a/.github/workflows/build-argocdinit.yml
+++ b/.github/workflows/build-argocdinit.yml
@@ -69,7 +69,8 @@ jobs:
           curl -fsSL https://goss.rocks/install | sh -s -- -b /tmp/goss/bin
           export PATH=/tmp/goss/bin:$PATH
           # newer goss versions take the filename as a positional argument
-          goss validate argocd/argocdinit/test/goss.yaml || (echo "goss checks failed"; docker logs test-container || true; exit 1)
+          # Use absolute path to avoid cwd/relative path issues inside dgoss wrappers
+          goss validate "$(pwd)/argocd/argocdinit/test/goss.yaml" || (echo "goss checks failed"; docker logs test-container || true; exit 1)
 
       - name: Stop test container
         if: always()


### PR DESCRIPTION
Use absolute path when invoking goss validate to avoid issues when dgoss changes working directory.